### PR TITLE
Add LivenessScore and update matching score logic

### DIFF
--- a/Client/MxFace.SDK.Face.API.Sample.Net/Components/Pages/Home.razor
+++ b/Client/MxFace.SDK.Face.API.Sample.Net/Components/Pages/Home.razor
@@ -38,6 +38,7 @@
             {
                 <div class="custom_card details_box w-100 mb-0">
                     <div class="detail_item_box"><strong>Quality:</strong> @uploadFaceResponse.Faces.FirstOrDefault().Quality</div>
+                    <div class="detail_item_box"><strong>Liveness:</strong> @uploadFaceResponse.LivenessScore</div>
                     <div class="detail_item_box"><strong>Age:</strong> @uploadFaceResponse.Faces.FirstOrDefault().FaceAnalytics.Age</div>
                     <div class="detail_item_box"><strong>Gender:</strong> @uploadFaceResponse.Faces.FirstOrDefault().FaceAnalytics.Gender</div>
                     <div class="detail_item_box"><strong>Emotion:</strong> @uploadFaceResponse.Faces.FirstOrDefault().FaceAnalytics.Emotion</div>
@@ -108,15 +109,18 @@
                     {
                         <div class="row g-3 align-items-center mt-4">
                             <div class="col-md-6">
-                                <label for="txtImageInfo" class="form-label fw-bold text-secondary">Matching Score:</label>
-                                <input type="text" value="@searchResponse.FirstOrDefault().MatchingScore" id="txtImageInfo" class="form-control" disabled />
+                                <label for="txtImageInfo" class="form-label fw-bold text-secondary">External Id:</label>
+                                <input type="text" value="@searchResponse.FirstOrDefault().ExternalId" id="txtImageInfo" class="form-control" disabled />
                             </div>
 
                             <div class="col-md-6">
                                 <label for="txtIsoTemplate" class="form-label fw-bold text-secondary">Image Data:</label>
                                 <textarea id="txtIsoTemplate" class="form-control" rows="2" disabled>@image1</textarea>
                             </div>
-
+                            <div class="col-md-6">
+                                <label for="txtImageInfo" class="form-label fw-bold text-secondary">Matching Score:</label>
+                                <input type="text" value="@searchResponse.FirstOrDefault().MatchingScore" id="txtImageInfo" class="form-control" disabled />
+                            </div>
 
                         </div>
                     }
@@ -170,7 +174,7 @@
         <div class="col-md-4">
             <div class="custom_card mb-0 p-3">
                 <small class="d-block mt-2 fw-bold text-danger text-center">
-                    If the matching score is <b>less than 15</b>, the images <b>do not match</b>.
+                    If the matching score is <b>less than 30</b>, the images <b>do not match</b>.
                     <b>Otherwise</b>, the images are considered a <b class="text-success">MATCH</b>.
                 </small>
                 <hr />

--- a/GRPCClient/MxFace.SDK.Face.GRPC.Client/Components/Pages/Home.razor
+++ b/GRPCClient/MxFace.SDK.Face.GRPC.Client/Components/Pages/Home.razor
@@ -37,6 +37,7 @@
             {
                 <div class="custom_card details_box w-100 mb-0">
                     <div class="detail_item_box"><strong>Quality:</strong> @uploadFaceResponse.Faces.FirstOrDefault().Quality</div>
+                    <div class="detail_item_box"><strong>Liveness:</strong> @uploadFaceResponse.LivenessScore</div>
                     <div class="detail_item_box"><strong>Age:</strong> @uploadFaceResponse.Faces.FirstOrDefault().FaceAnalytics.Age</div>
                     <div class="detail_item_box"><strong>Gender:</strong> @uploadFaceResponse.Faces.FirstOrDefault().FaceAnalytics.Gender</div>
                     <div class="detail_item_box"><strong>Emotion:</strong> @uploadFaceResponse.Faces.FirstOrDefault().FaceAnalytics.Emotion</div>

--- a/GRPCServer/MxFace.SDK.Face.GRPC/MxFace.SDK.Face.GRPC.csproj
+++ b/GRPCServer/MxFace.SDK.Face.GRPC/MxFace.SDK.Face.GRPC.csproj
@@ -22,4 +22,10 @@
     </Protobuf>
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="MxFace.SDK.Face">
+      <HintPath>bin\Debug\net8.0\MxFace.SDK.Face.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/Server/MxFace.SDK.Face.API/MxFace.SDK.Face.API.csproj
+++ b/Server/MxFace.SDK.Face.API/MxFace.SDK.Face.API.csproj
@@ -14,4 +14,10 @@
     <ProjectReference Include="..\..\Shared\MxFace.SDK.Face.API.Shared\MxFace.SDK.Face.API.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="MxFace.SDK.Face">
+      <HintPath>bin\Debug\net8.0\MxFace.SDK.Face.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/Shared/MxFace.SDK.Face.API.Shared/Models/UploadFaceResponse.cs
+++ b/Shared/MxFace.SDK.Face.API.Shared/Models/UploadFaceResponse.cs
@@ -3,6 +3,7 @@
 public class UploadFaceResponse : BaseResponse
 {
     public List<Analytics> Faces { get; set; }
+    public float LivenessScore { get; set; }
 }
 
 public class Analytics : FaceDetect

--- a/Shared/MxFace.SDK.Face.API.Shared/Proto/FaceProcessor.proto
+++ b/Shared/MxFace.SDK.Face.API.Shared/Proto/FaceProcessor.proto
@@ -20,6 +20,7 @@ message UploadFaceResponse {
     int32 Code = 3;
     string Error = 4;
     repeated Analytics Faces = 5;
+    float LivenessScore = 6;
 }
 
 message Analytics {


### PR DESCRIPTION
- Updated `Home.razor` to include "Liveness" detail in upload face response and rearranged matching score input.
- Changed matching score threshold from 15 to 30 for stricter matching criteria.
- Added `LivenessScore` property to `UploadFaceResponse` class.
- Updated `FaceProcessor.proto` to include `LivenessScore` in the gRPC message.
- Modified project files to reference `MxFace.SDK.Face` assembly for proper compilation.